### PR TITLE
fix: use correct struct in SlackApiFilesUploadResponse

### DIFF
--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -43,7 +43,5 @@ pub struct SlackApiFilesUploadRequest {
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Builder)]
 pub struct SlackApiFilesUploadResponse {
-    pub channel: SlackChannelId,
-    pub ts: SlackTs,
-    pub message: SlackMessage,
+    pub file: SlackFile,
 }


### PR DESCRIPTION
The response from the File Upload API is just a file object: https://api.slack.com/methods/files.upload#examples